### PR TITLE
Use CxxWrap.prefix_path() instead of now-gone CxxWrap.jlcxx_path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,5 +6,6 @@ version = "0.1.0"
 [deps]
 CMake = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,7 +15,6 @@ normaliz_local_dir=""
 if !haskey(ENV,"NORMALIZ_LOCAL_DIR")
     run(`git clone --depth=1 https://github.com/Normaliz/Normaliz`)
     cd(joinpath(@__DIR__, "Normaliz"))
-    ENV["NO_OPENMP"] = "yes"
     run(`./install_normaliz_with_eantic.sh`)
     normaliz_local_dir = joinpath(@__DIR__,"Normaliz","local")
 else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,8 +13,10 @@ julia_exec = joinpath(Sys.BINDIR , "julia")
 normaliz_local_dir=""
 
 if !haskey(ENV,"NORMALIZ_LOCAL_DIR")
+    normaliz_dir = joinpath(@__DIR__, "Normaliz")
+    isdir(normaliz_dir) && rm(normaliz_dir, recursive=true)
     run(`git clone --depth=1 https://github.com/Normaliz/Normaliz`)
-    cd(joinpath(@__DIR__, "Normaliz"))
+    cd(normaliz_dir)
     run(`./install_normaliz_with_eantic.sh`)
     normaliz_local_dir = joinpath(@__DIR__,"Normaliz","local")
 else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ import CMake
 # Parse some basic command-line arguments
 const verbose = "--verbose" in ARGS
 
-jlcxx_cmake_dir = joinpath(dirname(CxxWrap.jlcxx_path), "cmake", "JlCxx")
+jlcxx_cmake_dir = joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx")
 
 julia_exec = joinpath(Sys.BINDIR , "julia")
 

--- a/deps/src/normaliz.cpp
+++ b/deps/src/normaliz.cpp
@@ -8,7 +8,7 @@ using std::endl;
 #include "jlcxx/jlcxx.hpp"
 
 #include <libnormaliz/cone.h>
-#include <libnormaliz/map_operations.h>
+#include <libnormaliz/list_and_map_operations.h>
 #include <libnormaliz/vector_operations.h>
 using libnormaliz::Cone;
 // using libnormaliz::ConeProperty;


### PR DESCRIPTION
This change fixes a instant build error due to a change in CxxWrap: seemingly, `CxxWrap.jlcxx_path` existed at one point but doesn't anymore. The fix follows the approach described in https://github.com/JuliaInterop/CxxWrap.jl/pull/232 and uses `CxxWrap.prefix_path()` instead. 

With this change, the build at least gets going - but unfortunately ultimately doesn't succeed. Instead, after about ~25 min (maybe slow compilation because this is on WSL?) it throws a ```ERROR: LoadError: failed process: Process(`./install_normaliz_with_eantic.sh`, ProcessExited(2)) [2]``` build error (more output of `deps/build.log` below).

<details><summary>deps/build.log (last ~300 lines)</summary>
<p>

```log
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
Making all in test
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
Making all in example
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
make[1]: Nothing to be done for 'all-am'.
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
Making install in source
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
make[2]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
 /bin/mkdir -p '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib'
 /bin/bash ../libtool   --mode=install /usr/bin/install -c   libnormaliz.la '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib'
libtool: install: /usr/bin/install -c .libs/libnormaliz.so.3.8.10 /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libnormaliz.so.3.8.10
libtool: install: (cd /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib && { ln -s -f libnormaliz.so.3.8.10 libnormaliz.so.3 || { rm -f libnormaliz.so.3 && ln -s libnormaliz.so.3.8.10 libnormaliz.so.3; }; })
libtool: install: (cd /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib && { ln -s -f libnormaliz.so.3.8.10 libnormaliz.so || { rm -f libnormaliz.so && ln -s libnormaliz.so.3.8.10 libnormaliz.so; }; })
libtool: install: /usr/bin/install -c .libs/libnormaliz.lai /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libnormaliz.la
libtool: install: /usr/bin/install -c .libs/libnormaliz.a /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libnormaliz.a
libtool: install: chmod 644 /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libnormaliz.a
libtool: install: ranlib /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libnormaliz.a
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/mnt/c/Program Files (x86)/Common Files/Raytrix Shared/Bin/:/mnt/c/Program Files/MATLAB/R2018a/bin:/mnt/c/Program Files/MATLAB/R2018a/bin/win64:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/StrawberryPerl/c/bin:/mnt/c/StrawberryPerl/perl/site/bin:/mnt/c/StrawberryPerl/perl/bin:/mnt/c/Program Files/texlive/2018/bin/win32:/mnt/c/Anaconda3:/mnt/c/Users/tchr/AppData/Local/Microsoft/WindowsApps:/mnt/c/Program Files/Microsoft VS Code/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files (x86)/Wolfram Research/WolframScript/:/mnt/c/Program Files (x86)/Intel/Intel(R) Management Engine Components/DAL:/mnt/c/Program Files/Intel/Intel(R) Management Engine Components/DAL:/mnt/c/Program Files/Git/cmd:/mnt/c/Users/tchr/AppData/Roaming/npm:/mnt/c/Users/tchr/AppData/Local/atom/bin:/sbin" ldconfig -n /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
 /bin/mkdir -p '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/bin'
  /bin/bash ../libtool   --mode=install /usr/bin/install -c normaliz '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/bin'
libtool: install: /usr/bin/install -c .libs/normaliz /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/bin/normaliz
 /bin/mkdir -p '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/include'
 /bin/mkdir -p '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/include/libnormaliz'
 /usr/bin/install -c -m 644  ../../source/libnormaliz/automorph.h ../../source/libnormaliz/cone_property.h ../../source/libnormaliz/cone.h ../../source/libnormaliz/dynamic_bitset.h ../../source/libnormaliz/general.h ../../source/libnormaliz/HilbertSeries.h ../../source/libnormaliz/input_type.h ../../source/libnormaliz/integer.h ../../source/libnormaliz/libnormaliz.h ../../source/libnormaliz/list_and_map_operations.h ../../source/libnormaliz/matrix.h ../../source/libnormaliz/my_omp.h libnormaliz/nmz_config.h ../../source/libnormaliz/nmz_nauty.h ../../source/libnormaliz/normaliz_exception.h ../../source/libnormaliz/output.h ../../source/libnormaliz/sublattice_representation.h ../../source/libnormaliz/vector_operations.h libnormaliz/version.h '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/include/libnormaliz'
make[2]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
Making install in test
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
make[2]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/test'
Making install in example
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[2]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/example'
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
make[2]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build'
Making all in source
make[1]: Entering directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
/bin/bash ../libtool  --tag=CXX   --mode=link g++ -Wall -pedantic -Wno-unknown-pragmas -Wno-sign-compare  -g -O2  -L/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib  -all-static -o normaliz normaliz.o libnormaliz.la -larb  -lcocoa -leanticxx -leantic -larb -lflint -lflint -lmpfr -lnauty -lgmpxx -lgmp
libtool: link: g++ -Wall -pedantic -Wno-unknown-pragmas -Wno-sign-compare -g -O2 -static -o normaliz normaliz.o  -L/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib ./.libs/libnormaliz.a -lcocoa /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libeanticxx.a /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libeantic.a -larb -lflint /home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libmpfr.a -lnauty -lgmpxx -lgmp
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(eh_alloc.o): In function `(anonymous namespace)::pool::free(void*) [clone .constprop.2]':
(.text._ZN12_GLOBAL__N_14pool4freeEPv.constprop.2+0x1d): undefined reference to `pthread_mutex_lock'
(.text._ZN12_GLOBAL__N_14pool4freeEPv.constprop.2+0xe0): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(eh_alloc.o): In function `(anonymous namespace)::pool::allocate(unsigned long) [clone .constprop.3]':
(.text._ZN12_GLOBAL__N_14pool8allocateEm.constprop.3+0x21): undefined reference to `pthread_mutex_lock'
(.text._ZN12_GLOBAL__N_14pool8allocateEm.constprop.3+0x8b): undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libeantic.a(refine_embedding.o): In function `initialize_mtx':
refine_embedding.c:(.text+0x1a1): undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libeantic.a(refine_embedding.o): In function `renf_refine_embedding':
refine_embedding.c:(.text+0x1f1): undefined reference to `pthread_once'
refine_embedding.c:(.text+0x1fd): undefined reference to `pthread_mutex_lock'
refine_embedding.c:(.text+0x44d): undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2.o): In function `_fft_outer1_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:261: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:266: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:266: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2.o): In function `_fft_outer2_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:342: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:347: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:347: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2.o): In function `fft_mfa_truncate_sqrt2_outer':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:389: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2.c:458: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2_inner.o): In function `_fft_inner1_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:59: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:64: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:64: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2_inner.o): In function `_fft_inner2_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:108: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:113: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:113: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_fft_mfa_truncate_sqrt2_inner.o): In function `fft_mfa_truncate_sqrt2_inner':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:156: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/fft_mfa_truncate_sqrt2_inner.c:226: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_ifft_mfa_truncate_sqrt2.o): In function `_ifft_outer1_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:286: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:291: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:291: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_ifft_mfa_truncate_sqrt2.o): In function `_ifft_outer2_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:336: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:341: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:341: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_ifft_mfa_truncate_sqrt2.o): In function `ifft_mfa_truncate_sqrt2_outer':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:438: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/ifft_mfa_truncate_sqrt2.c:507: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_split_bits.o): In function `_split_limbs_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:46: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:51: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:51: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_split_bits.o): In function `_split_bits_worker':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:165: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:170: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:170: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_split_bits.o): In function `fft_split_limbs':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:80: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:116: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(fft_split_bits.o): In function `fft_split_bits':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:233: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/fft/split_bits.c:271: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_clear.o): In function `thread_pool_clear':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:21: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:29: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:35: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:36: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:37: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:38: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:39: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:40: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:29: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:35: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:36: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:37: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:38: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:39: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:40: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:29: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:35: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:36: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:37: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:38: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:39: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:40: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:48: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/clear.c:49: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_init.o): In function `thread_pool_idle_loop':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:32: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:42: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:43: undefined reference to `pthread_cond_wait'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:52: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_init.o): In function `thread_pool_init':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:71: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:76: undefined reference to `pthread_getaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:96: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:97: undefined reference to `pthread_cond_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:98: undefined reference to `pthread_cond_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:108: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:109: undefined reference to `pthread_create'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:111: undefined reference to `pthread_cond_wait'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/init.c:112: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_wait.o): In function `thread_pool_wait':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wait.c:22: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wait.c:30: undefined reference to `pthread_cond_wait'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wait.c:32: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_wake.o): In function `thread_pool_wake':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wake.c:21: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wake.c:29: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wake.c:40: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wake.c:42: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/wake.c:44: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_get_size.o): In function `thread_pool_get_size':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/get_size.c:19: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/get_size.c:23: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_give_back.o): In function `thread_pool_give_back':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/give_back.c:20: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/give_back.c:25: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/give_back.c:35: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/give_back.c:37: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_request.o): In function `thread_pool_request':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/request.c:25: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/request.c:45: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_restore_affinity.o): In function `thread_pool_restore_affinity':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/restore_affinity.c:25: undefined reference to `pthread_setaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/restore_affinity.c:32: undefined reference to `pthread_setaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_set_affinity.o): In function `thread_pool_set_affinity':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_affinity.c:35: undefined reference to `pthread_setaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_affinity.c:35: undefined reference to `pthread_setaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_affinity.c:35: undefined reference to `pthread_setaffinity_np'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_set_affinity.o):/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_affinity.c:43: more undefined references to `pthread_setaffinity_np' follow
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/local/lib/libflint.a(thread_pool_set_size.o): In function `thread_pool_set_size':
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:23: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:34: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:44: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:48: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:49: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:50: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:51: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:52: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:53: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:44: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:48: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:49: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:50: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:51: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:52: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:53: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:44: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:48: undefined reference to `pthread_cond_signal'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:49: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:50: undefined reference to `pthread_join'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:51: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:52: undefined reference to `pthread_cond_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:53: undefined reference to `pthread_mutex_destroy'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:95: undefined reference to `pthread_mutex_unlock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:72: undefined reference to `pthread_mutex_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:73: undefined reference to `pthread_cond_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:74: undefined reference to `pthread_cond_init'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:83: undefined reference to `pthread_mutex_lock'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:84: undefined reference to `pthread_create'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:86: undefined reference to `pthread_cond_wait'
/home/tchr/.julia/dev/Normaliz/deps/Normaliz/nmz_opt_lib/Flint_source/flint-2.6.3/thread_pool/set_size.c:87: undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale.o): In function `__gnu_cxx::__scoped_lock::~__scoped_lock()':
(.text._ZN9__gnu_cxx13__scoped_lockD2Ev[_ZN9__gnu_cxx13__scoped_lockD5Ev]+0x12): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale.o): In function `std::locale::facet::_S_get_c_locale()':
(.text._ZNSt6locale5facet15_S_get_c_localeEv+0x2f): undefined reference to `pthread_once'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale.o): In function `std::locale::_Impl::_M_install_cache(std::locale::facet const*, unsigned long)':
(.text._ZNSt6locale5_Impl16_M_install_cacheEPKNS_5facetEm+0x4e): undefined reference to `pthread_mutex_lock'
(.text._ZNSt6locale5_Impl16_M_install_cacheEPKNS_5facetEm+0xd6): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(c++locale.o): In function `std::Catalogs::_M_erase(int)':
(.text._ZNSt8Catalogs8_M_eraseEi+0x1b): undefined reference to `pthread_mutex_lock'
(.text._ZNSt8Catalogs8_M_eraseEi+0x92): undefined reference to `pthread_mutex_unlock'
(.text._ZNSt8Catalogs8_M_eraseEi+0x12b): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(c++locale.o): In function `std::Catalogs::_M_get(int) const':
(.text._ZNKSt8Catalogs6_M_getEi+0x1c): undefined reference to `pthread_mutex_lock'
(.text._ZNKSt8Catalogs6_M_getEi+0x8f): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(c++locale.o): In function `std::Catalogs::_M_add(char const*, std::locale)':
(.text._ZNSt8Catalogs6_M_addEPKcSt6locale+0x3d): undefined reference to `pthread_mutex_lock'
(.text._ZNSt8Catalogs6_M_addEPKcSt6locale+0xdb): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale_init.o): In function `std::locale::_S_initialize()':
(.text._ZNSt6locale13_S_initializeEv+0x1d): undefined reference to `pthread_once'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale_init.o): In function `std::locale::locale()':
(.text._ZNSt6localeC2Ev+0x43): undefined reference to `pthread_mutex_lock'
(.text._ZNSt6localeC2Ev+0x5e): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.a(locale_init.o): In function `std::locale::global(std::locale const&)':
(.text._ZNSt6locale6globalERKS_+0x45): undefined reference to `pthread_mutex_lock'
(.text._ZNSt6locale6globalERKS_+0xab): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2.o): In function `uw_init_context_1':
(.text+0x1e91): undefined reference to `pthread_once'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `__register_frame_info_bases.part.6':
(.text+0x1801): undefined reference to `pthread_mutex_lock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `__register_frame_info_table_bases':
(.text+0x1911): undefined reference to `pthread_mutex_lock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `__deregister_frame_info_bases':
(.text+0x19de): undefined reference to `pthread_mutex_lock'
(.text+0x1a65): undefined reference to `pthread_mutex_unlock'
(.text+0x1a8d): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `_Unwind_Find_FDE':
(.text+0x1bc4): undefined reference to `pthread_mutex_lock'
(.text+0x1c12): undefined reference to `pthread_mutex_unlock'
(.text+0x1d21): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `__register_frame_info_bases.part.6':
(.text+0x1834): undefined reference to `pthread_mutex_unlock'
/usr/lib/gcc/x86_64-linux-gnu/7/libgcc_eh.a(unwind-dw2-fde-dip.o): In function `__register_frame_info_table_bases':
(.text+0x1944): undefined reference to `pthread_mutex_unlock'
collect2: error: ld returned 1 exit status
Makefile:692: recipe for target 'normaliz' failed
make[1]: *** [normaliz] Error 1
make[1]: Leaving directory '/home/tchr/.julia/dev/Normaliz/deps/Normaliz/build/source'
Makefile:438: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
ERROR: LoadError: failed process: Process(`./install_normaliz_with_eantic.sh`, ProcessExited(2)) [2]

Stacktrace:
 [1] pipeline_error at ./process.jl:525 [inlined]
 [2] run(::Cmd; wait::Bool) at ./process.jl:440
 [3] run(::Cmd) at ./process.jl:438
 [4] top-level scope at /home/tchr/.julia/dev/Normaliz/deps/build.jl:19
 [5] include(::String) at ./client.jl:457
 [6] top-level scope at none:5
in expression starting at /home/tchr/.julia/dev/Normaliz/deps/build.jl:15
```
</p>
</details>

From reading the open issues, I gather that the long-term aim is to swap out the current build process for one based on artifacts - but in the interim, I would be happy if I could just get the package building so I could play with it (I've been using Normaliz in Julia in an awful way for months now: via PyCall and PyNormaliz 😨).

Unfortunately, I don't understand the artifact system nor CxxWrap very well, so I'm mostly flipping switches in the dark here; it seems this works though. This is a long way of saying that I realize this is as much a posting of an issue (and probably overlaps #4) as it is a PR.