### PR TITLE
Simplify JLL dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,10 @@ version = "0.1.0"
 
 [deps]
 CMake_jll = "3f4e10e2-61f2-5801-8945-23b9d642d0e6"
-CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
-FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
-GMP_jll = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-LLVMOpenMP_jll = "1d63c593-3942-5779-bab2-d838dc0a180e"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-MPFR_jll = "3a97d323-0669-5f0c-9066-3539efd106a3"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 normaliz_jll = "6690c6e9-4e12-53b8-b8fd-4bffaef8839f"
 
 [compat]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,13 +1,8 @@
 using CxxWrap
 import CMake_jll
-using Pkg
 using Pkg.Artifacts
 
 using normaliz_jll
-using GMP_jll
-using FLINT_jll
-using MPFR_jll
-using nauty_jll
 
 # Parse some basic command-line arguments
 const verbose = "--verbose" in ARGS
@@ -42,11 +37,11 @@ builddir = "build"
 rm(builddir; force=true, recursive=true)
 
 @static if Sys.isbsd()
-  using LLVMOpenMP_jll
-  libomp_path = LLVMOpenMP_jll.get_libomp_path()
+  using normaliz_jll.LLVMOpenMP_jll
+  libomp_path = normaliz_jll.LLVMOpenMP_jll.get_libomp_path()
 else
-  using CompilerSupportLibraries_jll
-  libomp_path = CompilerSupportLibraries_jll.get_libgomp_path()
+  using normaliz_jll.CompilerSupportLibraries_jll
+  libomp_path = normaliz_jll.CompilerSupportLibraries_jll.get_libgomp_path()
 end
 
 CMake_jll.cmake() do exe
@@ -55,16 +50,16 @@ CMake_jll.cmake() do exe
       -DJlCxx_DIR=$jlcxx_cmake_dir
       -DCMAKE_BUILD_TYPE=Release
       -Dnormaliz_prefix=$(jll_artifact_dir(normaliz_jll))
-      -Dgmp_prefix=$(jll_artifact_dir(GMP_jll))
-      -Dmpfr_prefix=$(jll_artifact_dir(MPFR_jll))
-      -Dnauty_prefix=$(jll_artifact_dir(nauty_jll))
-      -Dflint_prefix=$(jll_artifact_dir(FLINT_jll))
+      -Dgmp_prefix=$(jll_artifact_dir(normaliz_jll.GMP_jll))
+      -Dmpfr_prefix=$(jll_artifact_dir(normaliz_jll.MPFR_jll))
+      -Dnauty_prefix=$(jll_artifact_dir(normaliz_jll.nauty_jll))
+      -Dflint_prefix=$(jll_artifact_dir(normaliz_jll.FLINT_jll))
       -Dlibnormaliz_path=$(normaliz_jll.get_libnormaliz_path())
-      -Dlibgmp_path=$(GMP_jll.get_libgmp_path())
-      -Dlibgmpxx_path=$(GMP_jll.get_libgmpxx_path())
-      -Dlibmpfr_path=$(MPFR_jll.get_libmpfr_path())
-      -Dlibnauty_path=$(nauty_jll.get_libnauty_path())
-      -Dlibflint_path=$(FLINT_jll.get_libflint_path())
+      -Dlibgmp_path=$(normaliz_jll.GMP_jll.get_libgmp_path())
+      -Dlibgmpxx_path=$(normaliz_jll.GMP_jll.get_libgmpxx_path())
+      -Dlibmpfr_path=$(normaliz_jll.MPFR_jll.get_libmpfr_path())
+      -Dlibnauty_path=$(normaliz_jll.nauty_jll.get_libnauty_path())
+      -Dlibflint_path=$(normaliz_jll.FLINT_jll.get_libflint_path())
       -Dlibomp_path=$libomp_path
       -B $(builddir)
       -S .


### PR DESCRIPTION
All the JLLs we need are used by normaliz_jll, so access them through it
