### PR TITLE
Silence some CMake and CxxWrap warnings

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.01)
+cmake_minimum_required(VERSION 3.5)
 
 project(libnormaliz_julia)
 

--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-project(libormaliz_julia)
-
 cmake_minimum_required(VERSION 3.01)
+
+project(libnormaliz_julia)
+
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 

--- a/src/Normaliz.jl
+++ b/src/Normaliz.jl
@@ -5,8 +5,8 @@ import normaliz_jll
 
 using CxxWrap
 
-const libnormaliz_julia_path = joinpath(@__DIR__, "..", "deps", "src", "build", "lib", "libnormaliz_julia.$(Libdl.dlext)")
-@wrapmodule(libnormaliz_julia_path, :define_module_normaliz)
+get_libnormaliz_julia_path() = joinpath(@__DIR__, "..", "deps", "src", "build", "lib", "libnormaliz_julia.$(Libdl.dlext)")
+@wrapmodule(get_libnormaliz_julia_path, :define_module_normaliz)
 
 function __init__()
     @initcxx


### PR DESCRIPTION
This doesn't fix the EACCESS permissions error reported in #39, but it does fix the (trivial) warnings from CMake and another warning I saw from CxxWrap.