### PR TITLE
deps/build.jl: remove `touch` call

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -72,6 +72,3 @@ CMake_jll.cmake() do exe
       -j$(div(Sys.CPU_THREADS,2))
   `)
 end
-
-# force new precompilation
-touch(joinpath(@__DIR__, "..", "src", "Normaliz.jl"))


### PR DESCRIPTION
With recent CxxWrap, the 'touch' hack is not necessary anymore, as
CxxWrap itself already ensures that a changed `libnormaliz_julia`
leads to re-precompilation (via a `include_dependency` call).
