### PR TITLE
Move cone input normalization to Julia

### DIFF
--- a/deps/src/normaliz.cpp
+++ b/deps/src/normaliz.cpp
@@ -26,89 +26,20 @@ using libnormaliz::renf_elem_class;
 
 template <typename T>
 std::map<libnormaliz::Type::InputType, Matrix<T>>
-to_normaliz_matrix(jl_value_t* input_dict)
+to_normaliz_matrix(std::vector<std::string> input_keys,
+                   jlcxx::ArrayRef<Matrix<T>> input_matrices)
 {
-    if (!jl_isa(input_dict, jl_eval_string("Dict"))) {
-        jl_type_error("to_normaliz_matrix", jl_eval_string("Dict"),
-                      jl_typeof(input_dict));
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
+    size_t len = input_keys.size();
+    if (len != input_matrices.size()) {
+        throw std::runtime_error(
+            "Normaliz cone input keys and matrices must have the same length");
     }
-    jl_value_t* keys_iter = nullptr;
-    jl_value_t* vals_iter = nullptr;
-    jl_value_t* keys_array_value = nullptr;
-    jl_value_t* vals_array_value = nullptr;
-    jl_value_t* idx = nullptr;
-    jl_value_t* key_value = nullptr;
-    jl_value_t* mat_value = nullptr;
-    JL_GC_PUSH7(&keys_iter, &vals_iter, &keys_array_value, &vals_array_value,
-                &idx, &key_value, &mat_value);
-
-    keys_iter = jl_call1(jl_get_function(jl_base_module, "keys"), input_dict);
-    if (jl_exception_occurred()) {
-        JL_GC_POP();
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-    }
-
-    vals_iter = jl_call1(jl_get_function(jl_base_module, "values"), input_dict);
-    if (jl_exception_occurred()) {
-        JL_GC_POP();
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-    }
-
-    keys_array_value =
-        jl_call1(jl_get_function(jl_base_module, "collect"), keys_iter);
-    if (jl_exception_occurred()) {
-        JL_GC_POP();
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-    }
-    vals_array_value =
-        jl_call1(jl_get_function(jl_base_module, "collect"), vals_iter);
-    if (jl_exception_occurred()) {
-        JL_GC_POP();
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-    }
-    if (!jl_is_array(keys_array_value) || !jl_is_array(vals_array_value)) {
-        jl_value_t* actual_type =
-            jl_typeof(jl_is_array(keys_array_value) ? vals_array_value
-                                                    : keys_array_value);
-        JL_GC_POP();
-        jl_type_error("to_normaliz_matrix", jl_eval_string("Array"),
-                      actual_type);
-        return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-    }
-
-    jl_array_t* keys = reinterpret_cast<jl_array_t*>(keys_array_value);
-    jl_array_t* vals = reinterpret_cast<jl_array_t*>(vals_array_value);
-    size_t                                       len = jl_array_len(keys);
     std::map<libnormaliz::Type::InputType, Matrix<T>> input_map;
 
-    jl_function_t* getindex = jl_get_function(jl_base_module, "getindex");
     for (size_t i = 0; i < len; i++) {
-        idx = jl_box_int64(static_cast<int64_t>(i + 1));
-        key_value = jl_call2(getindex, keys_array_value, idx);
-        if (jl_exception_occurred()) {
-            JL_GC_POP();
-            return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-        }
-        mat_value = jl_call2(getindex, vals_array_value, idx);
-        if (jl_exception_occurred()) {
-            JL_GC_POP();
-            return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-        }
-        if (!jl_is_symbol(key_value)) {
-            JL_GC_POP();
-            jl_type_error("to_normaliz_matrix",
-                          reinterpret_cast<jl_value_t*>(jl_symbol_type),
-                          jl_typeof(key_value));
-            return std::map<libnormaliz::Type::InputType, Matrix<T>>();
-        }
-
-        Matrix<T>* mat = jlcxx::unbox<Matrix<T>*>(mat_value);
-        std::string key(
-            jl_symbol_name(reinterpret_cast<jl_sym_t*>(key_value)));
-        input_map[libnormaliz::to_type(key)] = Matrix<T>(*mat);
+        input_map[libnormaliz::to_type(input_keys[i])] =
+            Matrix<T>(input_matrices[i]);
     }
-    JL_GC_POP();
     return input_map;
 }
 
@@ -282,15 +213,24 @@ JLCXX_MODULE define_module_normaliz(jlcxx::Module& normaliz)
                                });
             });
 
-    normaliz.method("GMPCone", [](jl_value_t* input_dict) {
-        return Cone<mpz_class>(to_normaliz_matrix<mpq_class>(input_dict));
+    normaliz.method("_GMPCone", [](std::vector<std::string> input_keys,
+                                   jlcxx::ArrayRef<Matrix<mpq_class>>
+                                       input_matrices) {
+        return Cone<mpz_class>(
+            to_normaliz_matrix<mpq_class>(input_keys, input_matrices));
     });
-    normaliz.method("LongLongCone", [](jl_value_t* input_dict) {
-        return Cone<long long>(to_normaliz_matrix<mpq_class>(input_dict));
+    normaliz.method("_LongLongCone", [](std::vector<std::string> input_keys,
+                                        jlcxx::ArrayRef<Matrix<mpq_class>>
+                                            input_matrices) {
+        return Cone<long long>(
+            to_normaliz_matrix<mpq_class>(input_keys, input_matrices));
     });
 #ifdef ENFNORMALIZ
-    normaliz.method("RenfCone", [](jl_value_t* input_dict) {
-        return Cone<renf_elem_class>(to_normaliz_matrix<renf_elem_class>(input_dict));
+    normaliz.method("_RenfCone", [](std::vector<std::string> input_keys,
+                                    jlcxx::ArrayRef<Matrix<renf_elem_class>>
+                                        input_matrices) {
+        return Cone<renf_elem_class>(
+            to_normaliz_matrix<renf_elem_class>(input_keys, input_matrices));
     });
 #endif
 }

--- a/src/Normaliz.jl
+++ b/src/Normaliz.jl
@@ -32,6 +32,19 @@ Base.show(io::IO,x::NmzInteger) = print(io,to_string(x))
 Base.show(io::IO,x::NmzRational) = print(io,to_string(x))
 Base.show(io::IO,x::Cone) = print(io,"Normaliz cone")
 
+function _normaliz_input(input::AbstractDict)
+    input_pairs = collect(pairs(input))
+    input_keys = String[]
+    for (key, _) in input_pairs
+        key isa Symbol ||
+            throw(ArgumentError("Normaliz cone input keys must be Symbols"))
+        push!(input_keys, String(key))
+    end
+    input_keys = CxxWrap.StdLib.StdVector{CxxWrap.StdLib.StdString}(input_keys)
+    input_matrices = CxxRef.([matrix for (_, matrix) in input_pairs])
+    return input_keys, input_matrices
+end
+
 function NmzMatrix{T}(x::Matrix{S}) where S where T
    s = size(x)
    mat = NmzMatrix{T}(s[1],s[2])
@@ -49,6 +62,16 @@ end
 #    end
 #    return vec
 #end
+
+function GMPCone(input::AbstractDict)
+    input_keys, input_matrices = _normaliz_input(input)
+    return _GMPCone(input_keys, input_matrices)
+end
+
+function LongLongCone(input::AbstractDict)
+    input_keys, input_matrices = _normaliz_input(input)
+    return _LongLongCone(input_keys, input_matrices)
+end
 
 Cone{NmzInteger}(args...) = GMPCone(args...)
 Cone{BigInt}(args...)     = GMPCone(args...)

--- a/src/renf.jl
+++ b/src/renf.jl
@@ -32,4 +32,9 @@ function RenfClass(minpoly::String, gen::String, emb::String, prec::Int = 64)
   return renf_class_construct(minpoly, gen, emb, prec)
 end
 
+function RenfCone(input::AbstractDict)
+  normalized = _normaliz_input(input)
+  return _RenfCone(normalized.input_keys, normalized.input_matrices)
+end
+
 Cone{Renf}(args...)       = RenfCone(args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using Normaliz
+using CxxWrap
 
 @testset "basic NmzMatrix tests" begin
   xx = Normaliz.NmzMatrix{Normaliz.NmzRational}([1 2 ; 3 5])
@@ -7,6 +8,27 @@ using Normaliz
   xx = Normaliz.NmzMatrix{Normaliz.NmzInteger}([1 2 ; 3 5])
 
   xx = Normaliz.NmzMatrix{Int}([1 2 ; 3 5])
+end
+
+@testset "cone input normalization" begin
+  xx = Normaliz.NmzMatrix{Normaliz.NmzRational}([1//2 2 ; 3 5])
+  gg = Normaliz.NmzMatrix{Normaliz.NmzRational}([1 1])
+  input_keys, input_matrices = Normaliz._normaliz_input(Dict(:cone => xx, :grading => gg))
+  input_key_strings = collect(input_keys)
+
+  @test input_keys isa CxxWrap.StdLib.StdVector{CxxWrap.StdLib.StdString}
+  @test Set(input_key_strings) == Set(["cone", "grading"])
+  @test length(input_matrices) == 2
+
+  cone_index = findfirst(==("cone"), input_key_strings)
+  grading_index = findfirst(==("grading"), input_key_strings)
+  @test size(input_matrices[cone_index][]) == (2, 2)
+  @test string(input_matrices[cone_index][][1, 1]) == "1/2"
+  @test size(input_matrices[grading_index][]) == (1, 2)
+
+  mismatched_keys = CxxWrap.StdLib.StdVector{CxxWrap.StdLib.StdString}(["cone", "grading"])
+  err = @test_throws ErrorException Normaliz._LongLongCone(mismatched_keys, input_matrices[1:1])
+  @test err.value.msg == "Normaliz cone input keys and matrices must have the same length"
 end
 
 @testset "Second LongLongCone test" begin


### PR DESCRIPTION
Normalize public Dict inputs into key and matrix vectors before
calling the C++ wrapper.

Co-authored-by: Codex <codex@openai.com>
